### PR TITLE
Log the user out when wrong userID is entered

### DIFF
--- a/Subsurface/Subsurface/SDefines.h
+++ b/Subsurface/Subsurface/SDefines.h
@@ -20,6 +20,7 @@
 
 #define kUserIdKey  @"userID"
 
+#define kWrongUserID						@"WrongUserID"
 #define kDivesListLoadNotification          @"DivesListIsLoaded"
 #define kCreatedAccountNotification         @"NewlyCreatedAccountID"
 #define kDeletedAccountNotification         @"AccountDeleted"

--- a/Subsurface/Subsurface/Services/SWebService.m
+++ b/Subsurface/Subsurface/Services/SWebService.m
@@ -174,6 +174,10 @@ static SWebService *_staticWebService = nil;
          if (data.length > 0 && connectionError == nil) {
              
              NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+			 if ([json[@"error"] isEqualToString:@"Login invalid"]) {
+				 [[NSNotificationCenter defaultCenter] postNotificationName:kWrongUserID object:nil];
+				 return;
+			 }
              NSArray *divesListArray = json[@"dives"];
              
              NSMutableArray *updatedDives = [NSMutableArray arrayWithCapacity:divesListArray.count];

--- a/Subsurface/Subsurface/View Controllers/SDivesListTVC.m
+++ b/Subsurface/Subsurface/View Controllers/SDivesListTVC.m
@@ -59,6 +59,10 @@
                                              selector:@selector(divesListReceived:)
                                                  name:kDivesListLoadNotification
                                                object:nil];
+	[[NSNotificationCenter defaultCenter] addObserver:self
+											 selector:@selector(wrongUserID:)
+												 name:kWrongUserID
+											   object:nil];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -181,6 +185,16 @@
     _initialDivesList = _divesList.copy;
     [self.refreshControl endRefreshing];
     [self.tableView reloadData];
+}
+
+- (void)wrongUserID:(NSNotification *)notification {
+	UIAlertView *wrongIDAlert = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Error", "")
+														   message:NSLocalizedString(@"Wrong user ID please try again", "")
+														  delegate:self
+												 cancelButtonTitle:NSLocalizedString(@"Ok", "")
+												 otherButtonTitles: nil];
+	[wrongIDAlert show];
+	[self.navigationController popViewControllerAnimated:YES];
 }
 
 #pragma mark - UIRefreshControl handler


### PR DESCRIPTION
When the user enter a wrong userID, he is brought
back to the welcome view to enter the ID again.

I don know why the indentation looks so weird on git but it's perfectly fine.
